### PR TITLE
Gradle 2.13 -> 2.14.1

### DIFF
--- a/Library/gradle/wrapper/gradle-wrapper.properties
+++ b/Library/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
As a result of this error:

```
Error:(12, 1) A problem occurred evaluating root project 'Library'.
> Failed to apply plugin [id 'com.android.library']
   > Minimum supported Gradle version is 2.14.1.  Current version is 2.13. If using the gradle wrapper, try editing the distributionUrl in /Users/Vivan/src/pusher-websocket-android/Library/gradle/wrapper/gradle-wrapper.properties to gradle-2.14.1-all.zip
```

It might just be my system. @jpatel531 WDYT? 
