### PR TITLE
Report library version and name

### DIFF
--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -19,8 +19,6 @@ android {
     defaultConfig {
         minSdkVersion 9
         targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
     }
     testOptions {
         unitTests.returnDefaultValues = true

--- a/Library/src/main/java/com/pusher/android/PusherAndroidFactory.java
+++ b/Library/src/main/java/com/pusher/android/PusherAndroidFactory.java
@@ -28,7 +28,15 @@ public class PusherAndroidFactory {
     }
 
     public AsyncHttpClient newHttpClient() {
-        return Looper.myLooper() == Looper.getMainLooper() ? new AsyncHttpClient() : new SyncHttpClient();
+        AsyncHttpClient client;
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            client = new AsyncHttpClient();
+        } else {
+            client = new SyncHttpClient();
+        }
+        
+        client.addHeader("X-Pusher-Library", "pusher-websocket-android " + BuildConfig.VERSION_NAME);
+        return client;
     }
 
     public TokenUploadHandler newTokenUploadHandler(Context context, RegistrationListenerStack listenerStack) {


### PR DESCRIPTION
Add a header `X-Pusher-Library` that adds the name of the library along with the version number.

I also removed the `versionName` and `versionCode` from `defaultConfig` in `build.gradle` because these values override the values in `gradle.properties` when accessing the `VERSION_NAME` using `BuildConfig`

@jpatel531 
